### PR TITLE
v1.0.0 – Pushing to v1 with latest eslint rule updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
         'eslint-config-airbnb-base',
         './rules/best-practices',
         './rules/errors',
+        './rules/node',
         './rules/style',
         './rules/es6'
     ].map(require.resolve),

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@justeat/eslint-config-fozzie",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "description": "Just Eat's JS ESLint config, which follows our styleguide",
   "main": "index.js",
   "scripts": {
     "prelint": "editorconfig-tools check * rules/* test/*",
     "lint": "eslint .",
     "tests-only": "babel-tape-runner ./test/test-*.js",
-    "prepublish": "(in-install || eslint-find-rules --unused) && (not-in-publish || yarn test) && safe-publish-latest",
+    "prepublishOnly": "(in-install || eslint-find-rules --unused) && (not-in-publish || yarn test) && safe-publish-latest",
     "pretest": "yarn run lint",
     "test": "yarn run tests-only",
     "travis": "yarn run test"

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -1,5 +1,7 @@
 module.exports = {
     rules: {
+        'for-direction': 'error',
+
         // Disallow comparisons to negative zero
         // http://eslint.org/docs/rules/no-compare-neg-zero
         'no-compare-neg-zero': 'error'

--- a/rules/node.js
+++ b/rules/node.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        'no-buffer-constructor': 'off'
+    }
+};

--- a/rules/style.js
+++ b/rules/style.js
@@ -1,5 +1,7 @@
 module.exports = {
     rules: {
+        'array-bracket-newline': 'off',
+        'array-element-newline': 'off',
 
         // require camel case names
         camelcase: ['error', { properties: 'always' }],
@@ -54,6 +56,8 @@ module.exports = {
         // http://eslint.org/docs/rules/newline-per-chained-call
         'newline-per-chained-call': ['error', { ignoreChainWithDepth: 4 }],
 
+        'import/no-anonymous-default-export': 'off',
+
         // disallow multiple empty lines and only one newline at the end
         'no-multiple-empty-lines': ['error', { max: 4 }],
 
@@ -70,6 +74,8 @@ module.exports = {
         // ignore padding within blocks of code
         'padded-blocks': 'off',
 
+        'padding-line-between-statements': 'off',
+
         // require or disallow space before function opening parenthesis
         // http://eslint.org/docs/rules/space-before-function-paren
         'space-before-function-paren': ['error', {
@@ -77,6 +83,8 @@ module.exports = {
             named: 'always',
             asyncArrow: 'always'
         }],
+
+        'semi-style': ['error', 'last'],
 
         // require or disallow a space immediately following the // or /* in a comment
         // http://eslint.org/docs/rules/spaced-comment
@@ -89,6 +97,8 @@ module.exports = {
                 exceptions: ['-', '*'],
                 balanced: false
             }
-        }]
+        }],
+
+        'switch-colon-spacing': ['error', {'after': true, 'before': false}]
     }
 };


### PR DESCRIPTION
We’ve been running this package sub v1 for a while with no issues so wanted to move it to v1 with the Eslint v4 rule updates.

No real changes to the package itself, just a few rules that were unused with the previous version.