### PR TITLE
Fixing issue from unused rules #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ v2.0.0
 
 ### Added
 - `operator-linebreak` rule added (overrides base Airbnb setting)
+- `max-classes-per-file` errors if over 1 reference
+- `prefer-object-spread` enabled
 
 ### Removed
 - Rule for padding block code removed – will truncate all functions and tests.

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -3,6 +3,8 @@ module.exports = {
         // require default case in switch statements
         'default-case': ['error', { commentPattern: '^no default$' }],
 
+        'max-classes-per-file': ['error'],
+
         // disallow reassignments of native objects or read-only globals
         // http://eslint.org/docs/rules/no-global-assign
         'no-global-assign': ['error', { exceptions: [] }],

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -6,6 +6,8 @@ module.exports = {
                 commonjs: true,
                 caseSensitive: false
             }
-        ]
+        ],
+
+        'import/no-relative-parent-imports': 'off'
     }
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -51,6 +51,8 @@ module.exports = {
             ignoreTemplateLiterals: true
         }],
 
+        'max-lines-per-function': 'off',
+
         // enforces new line after each method call in the chain to make it
         // more readable and easy to maintain
         // http://eslint.org/docs/rules/newline-per-chained-call
@@ -75,6 +77,8 @@ module.exports = {
         'operator-linebreak': ['off'],
 
         'padding-line-between-statements': 'off',
+
+        'prefer-object-spread': 'error',
 
         // require or disallow space before function opening parenthesis
         // http://eslint.org/docs/rules/space-before-function-paren


### PR DESCRIPTION
Issue with publishing coming from prepublish – spotted rules not used now available in v5.

Have fixed this and update CHANGELOG