### PR TITLE
v2.0.1 - fixing small change in config rules from latest changes to airbnb config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v2.0.1
+------------------------------
+*July 13 2018*
+
+### Fixed
+- Added rule that changes `function-paren-newline` back to `multiline` (as this was changed by airbnb-config-eslint-base in it's latest update)
+
+
 v2.0.0
 ------------------------------
 *July 13 2018*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/eslint-config-fozzie",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Just Eat's JS ESLint config, which follows our styleguide",
   "main": "index.js",
   "scripts": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -10,6 +10,8 @@ module.exports = {
         // http://eslint.org/docs/rules/comma-dangle
         'comma-dangle': ['error', 'never'],
 
+        'function-paren-newline': ['error', 'multiline'],
+
         // this option sets a specific tab width for your code
         // http://eslint.org/docs/rules/indent
         indent: ['error', 4, {


### PR DESCRIPTION
### Fixed
- Added rule that changes `function-paren-newline` back to `multiline` (as this was changed by airbnb-config-eslint-base in it's latest update)