### PR TITLE
v3.1.2 – Syntax fix for import rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v3.1.2
+------------------------------
+*August 27, 2019*
+
+### Fixed
+- `no-unused-modules` set to `error` rather than `true`
+
+
 v3.1.1
 ------------------------------
 *June 17, 2019*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/eslint-config-fozzie",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Just Eat's JS ESLint config, which follows our styleguide",
   "main": "index.js",
   "scripts": {

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -12,6 +12,6 @@ module.exports = {
 
         'import/no-named-export': 'off',
 
-        'import/no-unused-modules': true
+        'import/no-unused-modules': 'error'
     }
 };


### PR DESCRIPTION
### Fixed
- `no-unused-modules` set to `error` rather than `true`