### PR TITLE
v3.5.0 - Update style rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ v3.5.0
 ------------------------------
 *November 20, 2020*
 
-### Fixed
+### Changed
 - Ignore template literals in `indent` rule as this can [cause "Cannot read property 'range' of null" errors](https://github.com/babel/babel-eslint/issues/681#issuecomment-652333293).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v3.5.0
+------------------------------
+*November 20, 2020*
+
+### Fixed
+- Ignore template literals in `indent` rule as this can [cause "Cannot read property 'range' of null" errors](https://github.com/babel/babel-eslint/issues/681#issuecomment-652333293).
+
+
 v3.4.1
 ------------------------------
 *April 4, 2020*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/eslint-config-fozzie",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Just Eat's JS ESLint config, which follows our styleguide",
   "main": "index.js",
   "scripts": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -32,9 +32,9 @@ module.exports = {
             SwitchCase: 1,
             VariableDeclarator: 1,
 
-            outerIIFEBody: 1,
+            ignoredNodes: ['TemplateLiteral'],
 
-            ignoredNodes: ['TemplateLiteral']
+            outerIIFEBody: 1
         }],
 
         // enforces spacing between keys and values in object literal properties

--- a/rules/style.js
+++ b/rules/style.js
@@ -32,7 +32,9 @@ module.exports = {
             SwitchCase: 1,
             VariableDeclarator: 1,
 
-            outerIIFEBody: 1
+            outerIIFEBody: 1,
+
+            ignoredNodes: ['TemplateLiteral']
         }],
 
         // enforces spacing between keys and values in object literal properties


### PR DESCRIPTION
### Changed
- Ignore template literals in `indent` rule as this can [cause "Cannot read property 'range' of null" errors](https://github.com/babel/babel-eslint/issues/681#issuecomment-652333293).